### PR TITLE
Add May 2026 analyses: consumer spending, private credit; resolve AV-002

### DIFF
--- a/.claude/orchestrator.md
+++ b/.claude/orchestrator.md
@@ -414,6 +414,10 @@ From `CONTRIBUTING.md`, prioritized:
 5. ✅ Energy/climate efficiency thesis — COMPLETED
 6. ✅ Biotech development costs — COMPLETED
 7. ✅ Commercial real estate vs. remote work — COMPLETED
+8. ✅ Labor market & AI impact — COMPLETED (April 2026)
+9. ✅ Digital assets cycle — COMPLETED (April 2026)
+10. ✅ Consumer spending / retail cycle — COMPLETED (May 2026)
+11. ✅ Private credit / BDC sector — COMPLETED (May 2026)
 
 ### Methodology Improvements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,14 +182,26 @@ Digital Assets Cycle Analysis (April 2026):
 - Key metrics: ETF flows, realized cap, MVRV, stablecoin supply
 - Supports predictions DA-001 through DA-005
 
-**Active predictions:** 42 total, resolution dates through 2027. See @docs/pre-registration.md for resolution protocol and @docs/prediction-prep/ for per-prediction resolution docs. Data pipelines in @scripts/ for reproducible metric snapshots.
+Consumer Spending & Retail Cycle Analysis (May 2026):
+- Examines whether the K-shaped consumer pattern is structural rather than cyclical
+- Key finding: Subprime auto 60+ DPD at 32-year record while top-quintile spending continues to expand
+- Key metrics: NY Fed delinquency series, NRF retail forecast, retail discount intensity
+- Supports predictions CS-001 through CS-005
+
+Private Credit & BDC Sector Analysis (May 2026):
+- Tests mark-to-model resilience as the asset class faces its first real cyclical default migration
+- Key finding: BCRED record redemptions ($3.8B / 7.9% AUM); FS KKR at 0.51x P/NAV; sponsor equities -41% to -66% from Sep 2025 highs
+- Key metrics: KBRA BDC non-accruals, BIZD vs HYG, BDC dividends, sponsor strategic actions
+- Supports predictions PC-001 through PC-005
+
+**Active predictions:** 52 total (50 pending, 2 resolved INCORRECT), resolution dates through 2027. See @docs/pre-registration.md for resolution protocol and @docs/prediction-prep/ for per-prediction resolution docs. Data pipelines in @scripts/ for reproducible metric snapshots.
 
 ### Upcoming Prediction Dates
 
 | ID | Prediction | Verification Date |
 |----|-----------|-------------------|
-| AV-001 | NVIDIA DC revenue growth <50% | Feb 2026 |
-| AV-002 | Hyperscaler capex language moderation | May 2026 |
+| AV-001 | NVIDIA DC revenue growth <50% | Feb 2026 — **Resolved INCORRECT** |
+| AV-002 | Hyperscaler capex language moderation | May 2026 — **Resolved INCORRECT** |
 | AV-003 | Open source GPT-4 parity on consumer GPU | Jun 30, 2026 |
 | EA-001 | Enterprise AI spending forecast <25% for 2027 | Jun 30, 2026 |
 | SC-002 | SOX underperforms S&P 500 in H1 2026 | Jul 1, 2026 |
@@ -222,6 +234,8 @@ See @analysis/enterprise-ai-adoption-2026-01.md for enterprise adoption metrics.
 See @analysis/energy-climate-2026-01.md for clean energy comparison.
 See @analysis/biotech-development-2026-01.md for drug development analysis.
 See @analysis/commercial-real-estate-2026-01.md for office market analysis.
+See @analysis/consumer-spending-2026-05.md for K-shape consumer analysis.
+See @analysis/private-credit-2026-05.md for BDC and private credit analysis.
 See @predictions/tracker.md for full track record.
 See @docs/prediction-calendar.md for resolution calendar.
 See @docs/analyst-comparison.md for Wall Street consensus comparison.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,8 +192,8 @@ git commit -m "Update: Refresh {metric} in {analysis}"
 3. ✅ **Real estate** — commercial real estate vs. remote work *(completed 2026-01-03)*
 4. ✅ **Labor market & AI impact** — aggregate vs. concentrated disruption *(completed 2026-04-18)*
 5. ✅ **Digital assets cycle** — post-ETF institutionalization thesis *(completed 2026-04-18)*
-6. ⬜ Consumer spending / retail cycle
-7. ⬜ Private credit / BDC sector
+6. ✅ **Consumer spending / retail cycle** — K-shape thesis with 5 predictions *(completed 2026-05-08)*
+7. ✅ **Private credit / BDC sector** — mark-to-model breakdown thesis with 5 predictions *(completed 2026-05-08)*
 
 ### Methodology improvements
 

--- a/analysis/ai-valuation-2026-01.md
+++ b/analysis/ai-valuation-2026-01.md
@@ -373,7 +373,7 @@ This section will be updated as predictions resolve.
 | Date Made | Prediction | Outcome Date | Result | Correct? |
 |-----------|-----------|--------------|--------|----------|
 | 2026-01-03 | NVIDIA DC revenue growth <50% Q4 FY26 | 2026-02-25 | DC revenue $62.3B (+75% YoY vs $35.6B) | **No** |
-| 2026-01-03 | Hyperscaler capex language moderation Q1 | 2026-05-XX | Pending | - |
+| 2026-01-03 | Hyperscaler capex language moderation Q1 | 2026-05-08 | All 4 raised/reiterated 2026 capex: MSFT $190B (+$25B for components), GOOGL $180–190B (raised), AMZN $200B (reiterated), META $125–145B (raised). No MSFT/GOOG/AMZN moderation language. | **No** |
 | 2026-01-03 | Open source GPT-4 parity on consumer GPU | 2026-06-30 | Pending | - |
 | 2026-01-03 | Enterprise AI spend growth <25% by Q3 | 2026-10-XX | Pending | - |
 | 2026-01-03 | NVIDIA+AMD+Arm market cap lower Dec 31 | 2026-12-31 | Pending | - |
@@ -383,14 +383,16 @@ This section will be updated as predictions resolve.
 **Accuracy Statistics:**
 
 - Total predictions: 7
-- Resolved: 1
+- Resolved: 2
 - Correct: 0
-- Incorrect: 1
-- Accuracy: 0% (n=1)
+- Incorrect: 2
+- Accuracy: 0% (n=2)
 
 **AV-001 resolution note (2026-04-19):** Prediction was wrong. NVIDIA reported Q4 FY26 Data Center revenue of $62.3B vs $35.6B prior-year, a 75% YoY increase — well above the 50% threshold. The efficiency thesis has **not** yet shown up in NVIDIA's reported growth; Blackwell/Rubin ramp offset whatever per-capability compute reduction was occurring. A single miss does not invalidate the broader thesis, but it is a concrete point against near-term deceleration. Longer-dated predictions (AV-005 Dec 2026, AV-007 end-2027) are still live and will test whether the efficiency dynamics eventually bind.
 
 The prep doc's prior-year baseline of $39.2B was wrong; the correct figure from NVIDIA's FY25 release is $35.6B. Outcome unaffected (75% >> 50%), but flagged as a data-discipline lesson for future prep docs.
+
+**AV-002 resolution note (2026-05-08):** Prediction was wrong. The Q1 2026 calendar earnings cycle (Apr 29 – May 1, 2026) produced no moderation language from MSFT/GOOG/AMZN. All four hyperscalers either raised or reiterated extremely aggressive 2026 capex: Microsoft pegged calendar 2026 at ~$190B (+~$25B vs prior expectations, attributed to "higher component pricing"); Alphabet raised to $180–190B (from $175–185B); Amazon reiterated $200B; Meta raised to $125–145B (from $115–135B). Combined Big-4 2026 guidance midpoint now ~$700B vs the $600B implicit in the January analysis — roughly a 17% upward revision in 4 months. The dominant exec narrative was **supply-side constraint**, not demand moderation: Pichai called Alphabet "compute constrained in the near term"; Hood said Microsoft "expects to remain constrained at least through 2026." The closest candidate for moderation language — Hood's "the efficiencies we're already driving across the platform" — was framed as confidence in returns *supporting more spend*, not as a brake. Two of the seven AI Valuation predictions have now resolved INCORRECT. The efficiency thesis remains live in its longer-dated forms (AV-005, AV-006, AV-007), but the near-term hyperscaler-moderation channel has clearly failed.
 
 ---
 
@@ -568,6 +570,7 @@ Updating this in the document rather than in a new file so the record remains au
 | 2026-01-03 | Initial publication |
 | 2026-04-19 | Resolved AV-001 as INCORRECT: NVIDIA Q4 FY26 DC revenue +75% YoY vs predicted <50% |
 | 2026-04-19 | Added April 2026 Interim Update: supply-constraint vs demand-destruction distinction; honest read on what the thesis got right/wrong |
+| 2026-05-08 | Resolved AV-002 as INCORRECT: no MSFT/GOOG/AMZN moderation language in Q1 2026 calendar earnings; all four hyperscalers raised or reiterated 2026 capex (combined ~$700B midpoint) |
 
 ---
 

--- a/analysis/consumer-spending-2026-05.md
+++ b/analysis/consumer-spending-2026-05.md
@@ -1,0 +1,248 @@
+# MARKET ACCURATE
+## Consumer Spending & Retail Cycle Analysis
+### May 8, 2026
+
+---
+
+> **Disclaimer**
+>
+> This is **experimental analysis**, not financial advice. The author has **no positions**
+> in securities discussed. Track record is **0/2 (n=2)** as of publication — see
+> predictions/tracker.md. Methodology is **unproven**. This represents one analytical
+> perspective; it may be partially or entirely wrong. Do your own research.
+>
+> **Version:** 0.1 (Initial publication)
+
+---
+
+# Executive Summary
+
+US consumer spending has bifurcated sharply since 2024. Aggregate retail growth remains positive (NRF projects +4.4% for 2026), but that average obscures a K-shaped pattern in which top-quintile spending continues to expand while the bottom two quintiles show flat-to-declining real discretionary outlays and rising payment stress. The most compressible signal: subprime 60+ day auto-loan delinquencies hit a **32-year record** in January 2026.
+
+**Central thesis (tested below):** The K-shape is structural rather than cyclical, and it will persist through 2026. The disconnect between aggregate strength and bottom-quintile distress means traditional headline consumer indicators (retail sales, PCE) will continue to mask a real recession-equivalent in the lower half. The cyclical risk is that one of the top-quintile pillars — equity wealth, services pricing power, or upper-income labor market — cracks before the lower half recovers, and the K folds inward.
+
+## Key Metrics (May 2026 baseline)
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Subprime auto loan 60+ DPD | 32-year record (highest since Jan 1994) | Fitch / Cox Automotive (Jan 2026 data) |
+| Credit card balances | $1.28T (+$44B QoQ in Q4 2025) | NY Fed |
+| Auto loan balances | $1.67T (+$12B QoQ) | NY Fed |
+| Average retail discount % (April 2026) | 32.0% (vs 35.0% prior year) | LSEG Retail tracker |
+| NRF 2026 retail sales forecast | +4.4% YoY to $5.6T | National Retail Federation |
+| Q1 2026 retail/restaurant earnings growth | +2.1% blended | LSEG/Refinitiv |
+| Q1 2026 retail/restaurant revenue growth | +6.1% blended | LSEG/Refinitiv |
+
+## Assessment
+
+- **High confidence:** K-shape is real and measurable in distinct data series (auto delinquency, discount-retailer trade-down, top-quintile services spending)
+- **Moderate confidence:** It persists through 2026 absent a labor-market shock to the top half
+- **Lower confidence:** Timing of any "K-fold" event in which the upper-income pillar cracks
+
+---
+
+# The K-Shape Thesis
+
+## Definition
+
+> The K-shape thesis holds that aggregate US consumer indicators (retail sales, PCE) understate income-distributional dispersion. Top-quintile households are increasing real spending while bottom-two-quintile households are reducing it, and the gap is widening rather than narrowing.
+
+If this is correct, three things follow:
+1. Headline retail strength is misleading and reflects the top half disproportionately
+2. Sector performance bifurcates: premium / luxury beats mid-tier, discount beats premium-aspirational mid-tier
+3. Stress signals (delinquencies, charge-offs) lead aggregate signals by 6–12 months
+
+## Evidence
+
+### 1. Subprime auto delinquencies at multi-decade records
+
+January 2026 subprime 60+ DPD auto loan delinquencies hit a 32-year record — the highest level since 1994. Prime auto delinquencies remained near recent norms. The divergence is the signal: it isn't a broad credit cycle, it's a borrower-segment-specific stress that maps to the bottom income quintiles.
+
+| Series | Q4 2024 | Q4 2025 | Change |
+|--------|---------|---------|--------|
+| Subprime auto 60+ DPD | ~5.0% | ~6.5% (Jan 2026 record) | +150 bps |
+| Prime auto 60+ DPD | <1% | <1% | Flat |
+
+Source: [Wolf Street Q4 2025 auto loan analysis](https://wolfstreet.com/2026/02/17/serious-delinquency-rates-for-subprime-prime-auto-loans-balances-and-debt-to-income-ratio-in-q4-2025/), [LendEDU 2026 auto delinquency analysis](https://lendedu.com/blog/auto-loan-delinquencies-defaults/), [Yahoo Finance: auto loan 32-year record](https://finance.yahoo.com/economy/articles/auto-loan-delinquencies-surge-32-150112001.html).
+
+### 2. Credit card balances at record but limit utilization rising
+
+Credit card balances reached $1.28T at end of Q4 2025 (+$44B QoQ), with aggregate limits up $95B in the same quarter. The quarter's transition into serious delinquency for credit cards ticked up; auto held or improved modestly for prime. Limits rising faster than balances has historically been associated with issuers extending credit to absorb stress — a coincident, not leading, indicator.
+
+Source: [NY Fed Household Debt Q4 2025](https://www.newyorkfed.org/microeconomics/topics/credit-cards-auto-loans), [Fed Note on consumer delinquency](https://www.federalreserve.gov/econres/notes/feds-notes/a-note-on-recent-dynamics-of-consumer-delinquency-rates-20251124.html).
+
+### 3. Discount-deeper-than-last-year promotional environment
+
+LSEG's April 2026 retail tracker shows the average percent discount has widened to 32.0% from 35.0% the prior year — i.e. a larger share of merchandise is being promoted, but at slightly shallower individual depths. Read: retailers are casting a wider net to capture value-conscious shoppers, not running deeper individual cuts.
+
+Source: [LSEG/Refinitiv retail trends April 2026](https://lipperalpha.refinitiv.com/2026/04/chasing-the-value-consumer-march-u-s-retail-sales-trends-and-q1-2026-earnings-setup/).
+
+### 4. Headline forecasts assume continued top-half resilience
+
+The NRF's 2026 retail forecast of +4.4% YoY to $5.6T assumes no top-quintile weakness. If equity-wealth-driven services consumption rolls over (e.g. a 20%+ S&P drawdown), this forecast is mechanically too high.
+
+Source: [NRF 2026 retail sales forecast](https://nrf.com/media-center/press-releases/nrf-forecasts-4-4-annual-retail-sales-growth-with-new-economic-model).
+
+## The K-fold risk
+
+Two pathways could cause the K to fold inward (i.e. top half joining bottom half in distress):
+
+| Channel | Trigger | Probability of triggering in 2026 |
+|---------|---------|----------------------------------|
+| Equity wealth shock | S&P 500 -20%+ drawdown | Moderate (reasonable cyclical odds) |
+| Upper-income labor weakness | Tech / professional services layoffs broaden meaningfully | Moderate (Labor Market analysis flagged concentrated disruption already) |
+| Services pricing exhaustion | Hospitality / leisure / dining demand softens | Moderate-Low |
+| Tariff pass-through | Tariff fatigue + wage volatility broadens (financial press flagged this for late 2025) | Moderate (per [FinancialContent: tariff fatigue](https://markets.financialcontent.com/stocks/article/marketminute-2026-1-27-us-consumer-spending-records-sharpest-decline-in-four-years-as-tariff-fatigue-and-wage-volatility-chill-2026-growth)) |
+
+---
+
+# Sector Read
+
+## Discount vs. premium retail
+
+| Cohort | Tickers | 2026 read |
+|--------|---------|-----------|
+| Deep discount | DG, DLTR, FIVE | Should outperform if K-shape persists; bottom-quintile trade-down support |
+| Off-price | TJX, ROST, BURL | Beneficiary of K-shape on both ends |
+| Mid-tier mall | M, KSS, GPS | Squeezed; thesis loser |
+| Premium | LULU, RH, WSM | Top-quintile dependent; rolls over if equity-wealth shock |
+| Luxury | LVMUY, RACE | Insulated from bottom half; vulnerable to top-half wealth effect |
+
+## Restaurants
+
+| Cohort | Read |
+|--------|------|
+| QSR (MCD, YUM, CMG) | Mixed — value menus performing, traffic from trade-down vs traffic loss from genuine cuts |
+| Casual dining (DRI, EAT) | Top-quintile dependent; tracks upper-income labor closely |
+| Fast casual premium (CAVA, SG) | Niche resilience; brand-loyalty narrative |
+
+---
+
+# Predictions
+
+## Pre-registered, time-bound, falsifiable
+
+### Prediction CS-001: Subprime auto delinquencies remain elevated
+**Claim:** US subprime auto loan 60+ DPD delinquency rate stays above 6.0% (vs January 2026 record of ~6.5%) in at least three of the four quarterly NY Fed Household Debt and Credit reports covering 2026.
+**Threshold:** ≥3 of 4 quarterly reports show subprime 60+ DPD > 6.0%.
+**Source:** [NY Fed Household Debt and Credit Report](https://www.newyorkfed.org/microeconomics/hhdc), Cox Automotive subprime delinquency series, Wolf Street tracking.
+**Ex-ante probability:** 70%
+**Verification date:** February 28, 2027 (Q4 2026 report typically published mid-Feb).
+
+### Prediction CS-002: Discount retailer outperformance
+**Claim:** A simple equal-weighted basket of (DG, DLTR, FIVE) total return outperforms a simple equal-weighted basket of (M, KSS, GPS) by ≥10 percentage points over the period May 8, 2026 → April 30, 2027.
+**Threshold:** Discount basket total return − mid-tier basket total return ≥ 10pp.
+**Source:** Yahoo Finance closing prices May 8, 2026 (baseline) and April 30, 2027 (resolution).
+**Ex-ante probability:** 55%
+**Verification date:** May 7, 2027.
+
+### Prediction CS-003: Credit card 90+ DPD breaches 4%
+**Claim:** Aggregate credit card 90+ DPD delinquency rate (NY Fed series) reaches or exceeds 4.0% in at least one quarter of 2026.
+**Threshold:** Quarterly Household Debt and Credit Report shows credit card 90+ DPD ≥4.0% in any quarter.
+**Source:** [NY Fed quarterly Household Debt and Credit Report](https://www.newyorkfed.org/microeconomics/hhdc).
+**Ex-ante probability:** 45%
+**Verification date:** February 28, 2027.
+
+### Prediction CS-004: NRF retail sales forecast misses
+**Claim:** Calendar-year 2026 actual US retail sales (per Census Bureau Monthly Retail Trade Report) grow by less than the NRF's +4.4% YoY forecast.
+**Threshold:** Census 2026 retail sales growth < 4.4%.
+**Source:** [Census Bureau Monthly Retail Trade Survey](https://www.census.gov/retail/index.html).
+**Ex-ante probability:** 55%
+**Verification date:** February 17, 2027 (Census typically publishes January data with annual revisions in mid-February).
+
+### Prediction CS-005: K-shape acknowledged in Fed communications
+**Claim:** At least one Federal Reserve Board governor or Reserve Bank president explicitly references "K-shaped" consumer dynamics or "income bifurcation" as a policy-relevant signal in a speech or testimony during 2026.
+**Threshold:** Documented mention in a Fed speech transcript or congressional testimony during calendar year 2026.
+**Source:** [Federal Reserve speeches archive](https://www.federalreserve.gov/newsevents/speeches.htm), Fed regional bank speech archives.
+**Ex-ante probability:** 75%
+**Verification date:** January 31, 2027.
+
+---
+
+# What Would Prove This Analysis Wrong
+
+| Thesis Element | Disconfirming Evidence |
+|----------------|----------------------|
+| K-shape is structural | Subprime auto 60+ DPD falls below 4% by Q3 2026 |
+| Bottom quintile distress is real | Lower-quintile real spending re-accelerates in Q2 2026 BEA data |
+| Discount retailers benefit | DG/DLTR/FIVE underperform mid-tier mall in 2026 |
+| Credit card stress builds | 90+ DPD falls and stays below 3.5% all year |
+| Top-half resilience holds | S&P 500 down >20% with PCE services growth still positive |
+
+---
+
+# Connections to Other Analyses
+
+| Other analysis | Connection |
+|----------------|-----------|
+| [Labor Market & AI](labor-market-ai-2026-04.md) | LM-001 (3.8–4.5% unemployment) and LM-003 (CSR headcount decline) are consistent with the K-shape: aggregate labor stable, lower-tier services occupations under pressure. |
+| [Commercial Real Estate](commercial-real-estate-2026-01.md) | Class A vs B/C office bifurcation mirrors the K-shape in CRE: high-quality holds, lower tier obsolescing. Same pattern across asset classes. |
+| [Hyperscaler Capex](hyperscaler-capex-2026-01.md) | If consumer ad spend falters in late 2026, Meta and Alphabet ad-revenue assumptions backing capex guidance face stress. Indirect link. |
+| [Energy & Climate](energy-climate-2026-01.md) | If lower-income tariff fatigue intensifies, EV adoption among bottom quintiles slows further; depresses near-term battery demand. |
+
+---
+
+# Track Record
+
+| Date Made | Prediction | Outcome Date | Result | Correct? |
+|-----------|-----------|--------------|--------|----------|
+| 2026-05-08 | CS-001: Subprime auto 60+ DPD >6% in ≥3/4 quarters of 2026 | 2027-02-28 | Pending | - |
+| 2026-05-08 | CS-002: Discount basket beats mid-tier mall by ≥10pp | 2027-05-07 | Pending | - |
+| 2026-05-08 | CS-003: Credit card 90+ DPD ≥4% in any 2026 quarter | 2027-02-28 | Pending | - |
+| 2026-05-08 | CS-004: 2026 retail sales growth < NRF's 4.4% forecast | 2027-02-17 | Pending | - |
+| 2026-05-08 | CS-005: Fed governor/president cites "K-shaped" consumer | 2027-01-31 | Pending | - |
+
+---
+
+# Methodology
+
+## Data Sources
+
+| Source | Usage |
+|--------|-------|
+| NY Fed Household Debt and Credit Report | Auto loan, credit card delinquency series |
+| Census Bureau Monthly Retail Trade | Aggregate retail sales |
+| BEA Personal Consumption Expenditures (PCE) | Income-quintile spending decomposition |
+| LSEG/Refinitiv Retail tracker | Promotional intensity, earnings expectations |
+| Cox Automotive | Subprime auto delinquency tracking |
+| NRF | Retail sales annual forecast |
+| Federal Reserve speeches archive | Policy commentary scan |
+
+## Epistemics
+
+| Claim type | Confidence | Examples |
+|------------|------------|----------|
+| Factual | High | Q4 2025 NY Fed data, January 2026 subprime delinquency record |
+| Analytical | Moderate | K-shape persistence, sector outperformance read |
+| Predictive | Moderate-Low | Specific threshold predictions above |
+
+## Limitations
+
+- NY Fed releases lag a quarter; Q1 2026 data not yet available at publication
+- Income-quintile decomposition relies on BEA's microsimulation methodology, which has known caveats
+- Sector basket predictions are sensitive to single-name idiosyncratic events (e.g. Macy's M&A would distort CS-002)
+- "Trade-down" measurement is indirect; would benefit from credit-card-spending-by-income-decile data (typically only available with multi-quarter lag)
+
+---
+
+# Replication
+
+This analysis is released under **CC0 1.0 Universal (Public Domain)**. Fork, improve, falsify.
+
+To replicate the predictions:
+1. Pull the NY Fed Household Debt and Credit Report PDF for each quarter
+2. Pull Yahoo Finance prices for the named tickers on the baseline and verification dates
+3. Pull Census Monthly Retail Trade for the calendar year
+4. Search Federal Reserve speeches archive for "K-shaped" or "income bifurcation"
+
+---
+
+# Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-08 | Initial publication |
+
+---
+
+*Market Accurate: Tracking the consumer split.*

--- a/analysis/hyperscaler-capex-2026-01.md
+++ b/analysis/hyperscaler-capex-2026-01.md
@@ -400,12 +400,84 @@ These are reconcilable: hyperscalers can guide capex higher *and* underdeliver b
 
 ---
 
+# May 2026 Update: Q1 2026 Earnings Cycle
+
+The Q1 2026 calendar-quarter earnings cycle (Apr 29 – May 1, 2026) has now closed. Reported results contradict the AV-002 prediction outright and force a substantial upward revision to the 2026 capex baseline.
+
+## Q1 2026 reported capex (calendar quarter)
+
+| Company | Q1 2026 Capex | YoY change | Source |
+|---------|---------------|-----------|--------|
+| Amazon | $43.2B | +56% (vs $27.7B Q1 2025 cash capex) | [CNBC Q1](https://www.cnbc.com/2026/04/29/amazon-amzn-q1-earnings-report-2026.html), Amazon IR |
+| Alphabet | $35.7B | +107% YoY | [CNBC GOOGL Q1](https://www.cnbc.com/2026/04/29/alphabet-googl-q1-2026-earnings.html), [Q1 release](https://www.sec.gov/Archives/edgar/data/1652044/000165204426000043/googexhibit991q12026.htm) |
+| Microsoft | $31.9B (Q3 FY26) | +49% YoY | [CNBC MSFT Q3](https://www.cnbc.com/2026/04/29/microsoft-msft-q3-earnings-report-2026.html), [The Register](https://www.theregister.com/2026/04/30/microsoft_q3_2026/) |
+| Meta | $19.8B | +~85% (vs ~$10.7B Q1 2025) | [Meta Q1 release](https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-First-Quarter-2026-Results/default.aspx) |
+| **Combined Big 4** | **$130.6B** | — | — |
+
+Q1 2026 alone was $130.6B — already 86% of the HC-001 $150B threshold, and Q4 is conventionally the highest-capex quarter.
+
+## Updated 2026 full-year guidance
+
+| Company | Old 2026 guidance (Q4 2025) | New 2026 guidance (Q1 2026) | Direction |
+|---------|----------------------------|----------------------------|-----------|
+| Microsoft | FY26 ~$94B; calendar 2026 implicit ~$170–175B | **~$190B calendar 2026** (incl. ~$25B for higher component pricing) | Raised |
+| Alphabet | $175–185B | **$180–190B** | Raised |
+| Amazon | ~$200B | **~$200B** | Reiterated |
+| Meta | $115–135B | **$125–145B** | Raised |
+| **Combined midpoint** | **~$625B** | **~$700B** | **+$75B in 4 months** |
+
+The combined midpoint moved from $625B (April-update baseline) to ~$700B in a single earnings cycle — a 12% upward revision.
+
+## Why guidance went up: the component-pricing wrinkle
+
+Microsoft and Meta both attributed material guidance increases to **higher component pricing** (memory/HBM, networking, transformers). This is mechanically distinct from "more capacity built":
+
+- Microsoft: ~$25B of the $190B is component-cost pass-through, not additional capacity
+- Meta: capex range raised "to reflect higher component pricing this year and, to a lesser extent, additional data center costs"
+
+This means a portion of the headline guidance increase is **inflation in unit costs** rather than additional unit volume. From an HC-001 perspective this still counts (it's reported capex), but it complicates the read on whether physical buildout is accelerating or merely getting more expensive.
+
+## Language audit: AV-002
+
+Despite the supply-constraint context, no MSFT/GOOG/AMZN executive used moderation language at the Q1 2026 earnings calls:
+
+| Company | Key capex language | Moderation? |
+|---------|-------------------|-------------|
+| Microsoft (Hood) | "remain constrained at least through 2026"; "the efficiencies we're already driving across the platform" (in context of confidence in returns) | No — efficiency mention frames *more spend*, not less |
+| Alphabet (Pichai) | "compute constrained in the near term"; CFO Ashkenazi: 2027 capex "will significantly increase" | No |
+| Amazon (Jassy) | Compared spending to "first major AWS growth wave" — i.e. justified upfront investment for compounding returns | No |
+| Meta (Li, contextual) | Capex raise "reflects higher component pricing... and additional data center costs to support future year capacity" | No |
+
+AV-002 resolved INCORRECT on May 8, 2026.
+
+## Implications for remaining predictions
+
+| Prediction | April Read | May Read |
+|-----------|-----------|----------|
+| **AV-002** (Q1 2026 moderation) | More likely CORRECT | **Resolved INCORRECT** |
+| **AV-007** (absolute capex reduction by end-2027) | Speculative | Still speculative; the path to a YoY reduction in 2027 now requires either a demand collapse or a hyperscaler exiting the AI capex race entirely. Microsoft's lease cancellations remain the closest precedent but were redirected to Oracle/Stargate, not eliminated. |
+| **HC-001** (Big-4 quarterly capex <$150B in 2026) | More likely INCORRECT | **Almost certainly INCORRECT.** Q1 2026 already $130.6B; with $700B annual midpoint implying ~$175B average quarterly and Q4 historically highest, Q4 2026 likely $180–200B+. |
+| **HC-002** (one hyperscaler lowers FY guidance mid-2026) | Unclear | **Tracking INCORRECT.** All four raised or held in Q1 2026; mid-year reduction would require an unusual demand reversal. Resolution date Oct 31, 2026 — Q2 2026 earnings (late July / early August) is the next gating event. |
+
+## What this means for the broader thesis
+
+The April update flagged a "two-narrative problem": efficiency-driven demand destruction (the original January thesis) vs. supply-side physical constraints. Q1 2026 earnings now strongly favor the **supply-constraint reading**:
+
+- Hyperscalers explicitly say they cannot build fast enough ("compute constrained")
+- Component pricing is up sharply (~$25B incremental for MSFT alone), suggesting demand >> supply for memory/HBM
+- Despite reported lease pullbacks (MSFT, AWS), aggregate guidance is up, not down
+
+Implication: the near-term hyperscaler capex story is no longer compatible with the original AI-Valuation-Analysis efficiency thesis at the *capex* level. It may still play out at the *valuation* level (compression in NVDA/AMD/ARM if the supply unblocks faster than expected, or if HBM/memory pricing rolls over) — but the "capex moderation" channel is closed.
+
+---
+
 # Changelog
 
 | Date | Change |
 |------|--------|
 | 2026-01-03 | Initial publication |
 | 2026-04-19 | Added April 2026 Interim Update: MSFT/AWS pullbacks, supply-constraint story, updated 2026 guidance ($650–690B combined), read on AV-002/007 and HC-001/002 |
+| 2026-05-08 | Added May 2026 Update with Q1 2026 reported capex ($130.6B Big-4), upward-revised 2026 guidance ($700B midpoint), AV-002 resolution, HC-001/002 read |
 
 ---
 

--- a/analysis/open-source-benchmarks-2026-01.md
+++ b/analysis/open-source-benchmarks-2026-01.md
@@ -287,11 +287,59 @@ Rough estimates of training cost to achieve benchmark performance:
 
 ---
 
+# May 2026 Refresh
+
+Data updated as of May 8, 2026. The original January data is preserved above. This section updates the metrics dashboard and identifies which models have shipped between January and May 2026.
+
+## New open-weights releases (Jan–May 2026)
+
+| Release | Date | Family | Notable claims |
+|---------|------|--------|----------------|
+| Qwen 3 (0.6B–32B base + 235B MoE) | Q1 2026 | Alibaba | 32B Q4 fits single RTX 4090 at ~38 tok/s; reported MMLU >87%, HumanEval >85%, GSM8K >93% on a Q4 quant |
+| Qwen 3.5 397B (Reasoning) | Q1 2026 | Alibaba | MMLU 91, GPQA 89; multi-GPU only (not RTX-4090-viable) |
+| Qwen 3.6-27B / 35B-A3B (MoE) | Apr 2026 | Alibaba | 27B variant reported to "beat 397B on coding" benchmarks; 35B-A3B MoE+SSM hybrid runs on RTX 4090 |
+| Llama 3.3 70B | Late 2025/early 2026 | Meta | 88% MMLU, 89% HumanEval, 90% GSM8K — but 70B Q4 ~40GB, requires multi-GPU |
+| DeepSeek V4 Pro (Max) | 2026 | DeepSeek | 91% MMLU, 91% HumanEval, 98% GSM8K; ~670B total parameters, NOT RTX-4090-viable |
+
+Sources: [BenchLM 2026 leaderboard](https://benchlm.ai/blog/posts/best-open-source-llm), [LLM-Stats Open LLM Leaderboard](https://llm-stats.com/leaderboards/open-llm-leaderboard), [Awesome Agents Home GPU Leaderboard](https://awesomeagents.ai/leaderboards/home-gpu-llm-leaderboard/), [ToolHalla Best Local LLMs RTX 4090 2026](https://toolhalla.ai/blog/best-local-llms-rtx-4090-2026), [BuildFastWithAI Qwen 3.6-27B review](https://www.buildfastwithai.com/blogs/qwen3-6-27b-review-2026).
+
+## Refreshed Metrics Dashboard
+
+| Metric | January 2026 value | May 2026 value | Trend |
+|--------|-------------------|----------------|-------|
+| Best open MMLU | 90.8% (DeepSeek-R1) | ~91% (DeepSeek V4 Pro Max) | Holding parity / leads |
+| Best open MMLU on single RTX 4090 | 87.5% (DeepSeek-R1-Distill-32B) | ~87% (Qwen 3 32B Q4) | Multiple candidates |
+| Best open HumanEval | 96.3% (DeepSeek-R1) | ~91% (DeepSeek V4 Pro Max reported) | Stable to lower (different eval methodology) |
+| Best open GSM8K | 97.3% (DeepSeek-R1) | ~98% (DeepSeek V4 Pro Max) | Stable |
+| Frontier gap (MMLU vs proprietary) | -2.1 (open leads) | Open still ≥ proprietary on MMLU | Holding |
+| Cost per frontier-class training | ~$5–10M | New runs reported in $5–8M range | Stable / slightly down |
+
+## Implications for OB-001 / OB-002 / OB-003
+
+| Prediction | January read | May 2026 read |
+|-----------|--------------|---------------|
+| **OB-001** (open-weights maintains <2pt gap to frontier through 2026) | Tracking favorably | **Tracking strongly favorable.** Open-weights still at parity with proprietary on MMLU; DeepSeek V4 Pro Max ~91 MMLU vs proprietary frontier (~90–91 from Claude Opus 4.6 / GPT-5 / Gemini 3 reported clusters). Through 2026 looks safe absent a 5+ point proprietary breakaway in H2. |
+| **OB-002** (4B model matches Llama 2 70B / MMLU ≥68% on mobile by Dec 2026) | Tracking favorably | Indeterminate. Qwen 3 4B has not been individually benchmarked at MMLU 68%+ in public sources reviewed; smaller 7–8B models clearly clear it. Need targeted check of Qwen 3 small variants and Phi-4-mini class models in next refresh. |
+| **OB-003** (frontier-class training MMLU >85% for under $1M) | Tracking favorably | Borderline. Multiple sub-$10M frontier-class runs reported, but **strict <$1M with documented training cost and MMLU >85%** is harder to verify. Need primary-source training-cost disclosure (not estimate). |
+
+## Implications for AV-003 (RTX 4090 GPT-4 parity)
+
+The expansion of qualifying RTX-4090-viable candidates from one (DeepSeek-R1-Distill-32B in Jan) to ≥3 (add Qwen 3 32B and Qwen 3.6 35B-A3B) materially strengthens the case for AV-003 CORRECT. See `docs/prediction-prep/AV-003-prep.md` May 2026 addendum for the full candidate list.
+
+## What this refresh does NOT change
+
+- The **proprietary breakaway risk** (a closed-source model opens a >2pt MMLU lead) has not yet materialized but cannot be ruled out for Q3/Q4 2026.
+- **Benchmark contamination concerns** remain. MMLU saturation (multiple models clustered at 87–91%) means benchmark-as-discriminator is decaying; future tracking should add GPQA, LiveCodeBench, and SWE-Bench Verified.
+- The original thesis that "compute scarcity premiums are eroding" is not refuted by these data — but as the AV-002 May 2026 resolution shows, the *capex transmission channel* has not yet bound.
+
+---
+
 # Changelog
 
 | Date | Change |
 |------|--------|
 | 2026-01-03 | Initial publication |
+| 2026-05-08 | Added May 2026 Refresh: new releases (Qwen 3, Qwen 3.5/3.6, DeepSeek V4 Pro, Llama 3.3); updated metrics dashboard; OB-001/002/003 status reads; AV-003 strengthening |
 
 ---
 

--- a/analysis/private-credit-2026-05.md
+++ b/analysis/private-credit-2026-05.md
@@ -1,0 +1,251 @@
+# MARKET ACCURATE
+## Private Credit & BDC Sector Analysis
+### May 8, 2026
+
+---
+
+> **Disclaimer**
+>
+> This is **experimental analysis**, not financial advice. The author has **no positions**
+> in securities discussed. Track record is **0/2 (n=2)** as of publication — see
+> predictions/tracker.md. Methodology is **unproven**. This represents one analytical
+> perspective; it may be partially or entirely wrong. Do your own research.
+>
+> **Version:** 0.1 (Initial publication)
+
+---
+
+# Executive Summary
+
+The private credit asset class — and the publicly traded Business Development Companies (BDCs) that offer the most transparent window into it — entered a discrete repricing event in late 2025 that accelerated through Q1 2026. Major BDC equity sponsors (Apollo, Blackstone, Ares, KKR, Blue Owl) are down 41–66% from September 2025 highs. Blackstone's flagship BCRED non-traded fund saw $3.8B (7.9% of AUM) of redemption requests in a single quarter, with the firm injecting $400M of its own capital to meet them. FS KKR Capital Corp trades at ~51 cents per dollar of NAV.
+
+**Central thesis (tested below):** Private credit has been priced as a low-volatility yield product but is structurally a senior secured corporate loan portfolio with mark-to-model NAV smoothing. The 2026 episode is the first cycle in which the asset class faces real cyclical default migration *while* simultaneously facing redemption pressure. The mark-to-model machinery breaks down once redemption gates are tested. The question is not whether more BDCs cut dividends or trade below NAV — they will — but whether the contagion stays inside private credit or transmits to bank balance sheets, equity multiples, or the leveraged loan market.
+
+## Key Metrics (May 2026 baseline)
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| BDC industry AUM | $565B (2026E, +20% YoY) | KBRA |
+| Total private credit market | ~$2.0T (towards $3T by 2028) | KBRA, Mawer, S&P |
+| Median BDC non-accruals (Q3 2025) | 2.5% at cost / 1.3% at fair value | KBRA Q3 2025 compendium |
+| BCRED non-performing loan ratio (Q1 2026) | 2.4% (record high for BCRED) | Fortune, BCRED Q1 update |
+| BCRED redemptions (Q1 2026) | $3.8B (7.9% of $82B AUM) | US News, Fortune |
+| FS KKR Capital quarterly dividend | $0.48 (cut from $0.64, -25%) | BiggoFinance |
+| FS KKR Capital price/NAV | ~0.51 | BiggoFinance |
+| Sponsor equity drawdown (Sep 2025–Mar 2026) | Apollo -41%, Blackstone -46%, Ares -48%, KKR -48%, Blue Owl -66% | Fortune |
+| Q1 2026 leveraged loan market change | -34% (issuance) | FinancialContent |
+
+## Assessment
+
+- **High confidence:** Private credit is in a discrete repricing cycle, not a sentiment squiggle
+- **Moderate confidence:** Non-traded BDCs face structural redemption pressure that will continue through 2026
+- **Lower confidence:** Whether contagion spreads to senior bank loans, regional banks, or broader equity markets
+
+---
+
+# The Mark-to-Model Problem
+
+## Definition
+
+> Private credit BDCs report Net Asset Value (NAV) using internal valuation methodologies that are not directly observable in secondary markets. Two-thirds of BDC investments are level-3 fair value, meaning they have no quoted prices. The mark-to-model NAV is therefore a function of methodology, not market price.
+
+This produces three structural features:
+1. **Smoothed reported NAV** during periods when underlying loans are stressed but not yet defaulted
+2. **Discrete revaluation events** when defaults force specific loan markdowns
+3. **Redemption asymmetry** for non-traded BDCs: investors redeem at NAV (smoothed up), but the fund must liquidate at market (often markedly lower)
+
+Public BDCs solve this in part by trading equity at a discount or premium to NAV. The current ~0.51x P/NAV at FS KKR is the market saying: "We don't believe the reported NAV."
+
+## Evidence the cycle has turned
+
+### 1. BCRED's $400M owner injection
+
+Blackstone (BX) injecting $400M of its own balance sheet capital plus senior executive personal capital into BCRED to satisfy redemptions is a non-routine action. It signals the fund could not meet the redemption queue from portfolio cash alone, and that gating would have been the alternative. Sources: [US News on BCRED outflows](https://money.usnews.com/investing/news/articles/2026-03-02/blackstones-82-billion-private-credit-fund-sees-net-outflows), [Fortune on the meltdown](https://fortune.com/2026/03/14/private-credit-meltdown-how-wall-streets-blackstone-kkr-apollo-ares-blue-owl-investment-craze-panic/).
+
+### 2. NAV erosion at the loan level, not just the fund level
+
+The Medallia and Affordable Care defaults triggered a $4.4B wave at Blackstone, KKR, Apollo. The BCRED-specific markdown moved a class of loans from 80c to 60c on the dollar — a 25% loss of value on the affected book. This is the kind of mark migration that the model previously suppressed. Source: [BiggoFinance on $4.4B default wave](https://finance.biggo.com/news/9RUH8p0BaoGGrU-IOhrZ).
+
+### 3. Dividend cuts are starting
+
+FS KKR Capital Corp cut its quarterly dividend from $0.64 to $0.48 (-25%) — the first major public BDC dividend cut of the cycle. BDC dividends are mechanically driven by net investment income (NII), which is interest received minus interest paid minus opex. A dividend cut means NII has declined, typically because of (a) PIK conversion (loans paying in kind rather than cash), (b) non-accrual status moves, or (c) realized losses. Source: [BiggoFinance on FS KKR](https://finance.biggo.com/news/9RUH8p0BaoGGrU-IOhrZ).
+
+### 4. Public BDC equity says NAV is overstated
+
+When a publicly traded BDC trades at 51c per $1 of NAV (FS KKR), the market is implicitly saying the NAV should be ~50% lower. The equity discount is the market's fast-cycle correction; the NAV will follow, with a lag, as defaults materialize and become realized losses.
+
+### 5. The asset gathering reverses
+
+KBRA's Q3 2025 BDC compendium flagged "selective borrower underperformance" and "late-cycle softening." Q1 2026 made that explicit. The BDC industry's projected growth from $565B (2026) to $1.37T (2030) — quoted in [Alternative Credit Investor](https://alternativecreditinvestor.com/2026/04/28/bdc-market-to-triple-by-2030/) — assumes continued asset-gathering. That assumption is being tested in real time.
+
+---
+
+# What Could Stop the Cycle
+
+A real bull-case for private credit in 2026 H2:
+
+| Channel | Mechanism | Probability of activating |
+|---------|-----------|--------------------------|
+| Fed cuts | Rate cuts compress floating-rate yields but also lower default pressure on borrowers | Moderate |
+| Spread compression | If new private credit deals tighten substantially, existing book gets repriced upward | Low (no new spread compression visible) |
+| Bank disintermediation accelerates again | Banks pull back from middle-market lending; private credit reabsorbs flows | Low — banks not pulling back at this point in cycle |
+| Sponsor capital injections continue | Blackstone-style support sustains specific funds | Possible, but doesn't fix industry |
+| Default rates revert | Q2/Q3 2026 defaults drop sharply (Medallia, Affordable Care were idiosyncratic) | Low — these are pattern, not point events |
+
+## Bear-case mechanisms
+
+| Channel | Mechanism | Probability |
+|---------|-----------|-------------|
+| Redemption gates | Non-traded BDCs invoke gating clauses; investors lose access | Moderate-High |
+| Cross-fund contagion | Same sponsor's funds compared; weakest get redeemed first; sponsor equity hit | High (already happening) |
+| Insurance-channel wobble | Insurance-affiliated private credit (Athene, Apollo's largest distribution channel) faces regulator scrutiny | Moderate |
+| Bank loan exposure | Banks that lent to BDC sponsors via NAV facilities or sub-line revolvers face mark-down | Moderate |
+| Credit pull from middle market | Mid-market companies face refinancing wall; funds unwilling to extend | High |
+
+---
+
+# Where This Connects to Other Market Accurate Theses
+
+## AI capex and private credit
+
+Hyperscaler AI capex is being financed via cash flow, but the *secondary* AI ecosystem (Stargate-style data center JVs, neocloud GPU operators like CoreWeave, AI infrastructure SPVs) increasingly relies on private credit and structured debt. If private credit pricing power weakens, AI infra financing costs rise. This is a tail risk for the supply-constrained capex story documented in the [Hyperscaler Capex Tracker](hyperscaler-capex-2026-01.md) May 2026 update.
+
+## Commercial real estate parallel
+
+The Class A vs Class B/C office market bifurcation in [Commercial Real Estate](commercial-real-estate-2026-01.md) has the same structure as the BDC sponsor bifurcation: the largest and best-positioned holders (Blackstone, top-tier CRE) trade at premium multiples; the weak holders (FS KKR, Class B/C office) trade at deep discounts. Same liquidity dynamics, different asset.
+
+## Consumer credit parallel
+
+The K-shape consumer thesis (see [Consumer Spending](consumer-spending-2026-05.md)) maps onto the corporate borrower base: top-quintile corporate borrowers are fine; bottom-quintile (smaller, weaker-margin, sponsor-LBO'd) are stressed. Subprime auto delinquencies are the consumer analogue of BDC non-accruals.
+
+---
+
+# Predictions
+
+## Pre-registered, time-bound, falsifiable
+
+### Prediction PC-001: BDC industry non-accruals rise materially
+**Claim:** Median non-accrual rate at cost across rated BDCs (KBRA universe) reaches or exceeds 4.0% in at least one quarterly KBRA BDC Compendium covering 2026.
+**Baseline:** Median non-accruals at cost was 2.5% in Q3 2025.
+**Threshold:** Any 2026 quarterly KBRA report shows median ≥4.0% at cost.
+**Source:** [KBRA BDC Ratings Compendium](https://www.kbra.com/publications/tmPgxxsR/private-credit-business-development-company-bdc-ratings-compendium-third-quarter-2025-and-2026-outlook).
+**Ex-ante probability:** 55%
+**Verification date:** February 28, 2027.
+
+### Prediction PC-002: Major BDC dividend cut wave
+**Claim:** At least 5 publicly traded BDCs (with market cap >$500M at May 8, 2026) cut their quarterly base dividend by ≥10% in calendar 2026.
+**Baseline:** FS KKR Capital cut by 25% in Q1 2026; one cut so far.
+**Threshold:** 4 additional cuts of ≥10% in regular base dividend (excluding "supplemental" or "special" dividends) before Dec 31, 2026.
+**Source:** Public BDC press releases, BDC Investor tracker.
+**Ex-ante probability:** 70%
+**Verification date:** January 31, 2027.
+
+### Prediction PC-003: Non-traded BDC gating event
+**Claim:** At least one major non-traded perpetual BDC (>$10B AUM at start of 2026) invokes its quarterly redemption gate or formally suspends share repurchases in 2026.
+**Threshold:** Documented gate invocation or repurchase suspension in any major non-traded BDC SEC filing, press release, or investor letter during 2026.
+**Source:** SEC EDGAR filings, sponsor investor relations sites.
+**Ex-ante probability:** 50%
+**Verification date:** January 31, 2027.
+
+### Prediction PC-004: BDC ETF underperforms HYG
+**Claim:** BIZD (the VanEck BDC Income ETF) total return underperforms HYG (iShares iBoxx High Yield Corporate Bond ETF) by ≥10 percentage points over the period May 8, 2026 → December 31, 2026.
+**Threshold:** BIZD total return − HYG total return ≤ -10pp.
+**Source:** Yahoo Finance closing prices.
+**Ex-ante probability:** 55%
+**Verification date:** January 1, 2027.
+
+### Prediction PC-005: Sponsor M&A or wind-down
+**Claim:** At least one publicly traded BDC sponsor (Apollo, Blackstone, Ares, KKR, Blue Owl, FS Investments) announces a strategic transaction (sale, merger, or wind-down) of a private credit business unit in 2026.
+**Threshold:** Documented announcement of asset sale, merger, or wind-down of a credit-related fund family.
+**Source:** SEC 8-K filings, sponsor press releases, WSJ/FT/Bloomberg coverage.
+**Ex-ante probability:** 40%
+**Verification date:** January 31, 2027.
+
+---
+
+# What Would Prove This Analysis Wrong
+
+| Thesis Element | Disconfirming Evidence |
+|----------------|----------------------|
+| Cycle has turned | Median BDC non-accruals fall below 2.0% by Q3 2026 |
+| Mark-to-model is breaking | All major non-traded BDCs report stable NAV through 2026 |
+| Sponsor equity decline reflects fundamentals | BX, KKR, ARES, APO, OWL all rally back to within 10% of Sep 2025 highs by year-end |
+| Redemption pressure is structural | BCRED returns to net inflows in Q3 or Q4 2026 |
+| FS KKR-style discounts spread | Median public BDC P/NAV stays above 0.85 through 2026 |
+
+---
+
+# Connections to Other Analyses
+
+| Other analysis | Connection |
+|----------------|-----------|
+| [Consumer Spending](consumer-spending-2026-05.md) | K-shape thesis maps to corporate borrowers; bottom-tier corporates ≈ subprime consumers |
+| [Commercial Real Estate](commercial-real-estate-2026-01.md) | Same bifurcation dynamic between top and bottom tier |
+| [Hyperscaler Capex](hyperscaler-capex-2026-01.md) | Secondary AI infrastructure financing relies on private credit; spread widening flows back to neocloud capex |
+| [Semiconductor Cycle](semiconductor-cycle-2026-01.md) | Sponsor-LBO portfolio company stress contains a meaningful tech-services exposure |
+
+---
+
+# Track Record
+
+| Date Made | Prediction | Outcome Date | Result | Correct? |
+|-----------|-----------|--------------|--------|----------|
+| 2026-05-08 | PC-001: BDC median non-accruals ≥4% in any 2026 quarter | 2027-02-28 | Pending | - |
+| 2026-05-08 | PC-002: 5+ BDC dividend cuts of ≥10% in 2026 | 2027-01-31 | Pending | - |
+| 2026-05-08 | PC-003: Major non-traded BDC gating event in 2026 | 2027-01-31 | Pending | - |
+| 2026-05-08 | PC-004: BIZD underperforms HYG by ≥10pp May→Dec 2026 | 2027-01-01 | Pending | - |
+| 2026-05-08 | PC-005: Sponsor M&A or wind-down of credit business | 2027-01-31 | Pending | - |
+
+---
+
+# Methodology
+
+## Data Sources
+
+| Source | Usage |
+|--------|-------|
+| KBRA BDC Ratings Compendium (quarterly) | Industry non-accrual, NII, NAV trends |
+| SEC EDGAR 10-Q / 10-K / 8-K | Per-BDC disclosures |
+| BDC Investor tracker | Universe-level dividend, NAV, P/NAV history |
+| Sponsor investor relations | BCRED, OBDC, FSK, ARCC, etc. updates |
+| Yahoo Finance | Total return calculations |
+| Fortune / WSJ / FT / Bloomberg | Cycle event coverage |
+
+## Epistemics
+
+| Claim type | Confidence | Examples |
+|------------|------------|----------|
+| Factual | High | Q1 2026 BCRED redemption figures, sponsor stock declines, FS KKR dividend cut |
+| Analytical | Moderate | Mark-to-model breakdown thesis, contagion channels |
+| Predictive | Moderate-Low | 2026 specific threshold predictions above |
+
+## Limitations
+
+- Private credit data lags public markets by 1–2 quarters
+- Non-traded BDC NAVs are not independently audited mid-quarter
+- KBRA's universe is rated BDCs; substantial non-rated tail not visible
+- Industry response (gating, wind-down, sponsor M&A) is inherently lumpy and discrete
+
+---
+
+# Replication
+
+This analysis is released under **CC0 1.0 Universal (Public Domain)**. Fork, improve, falsify.
+
+To replicate the predictions:
+1. Pull each quarterly KBRA BDC Ratings Compendium for non-accrual data
+2. Track public BDC dividends via SEC 8-K filings and sponsor IR
+3. Monitor SEC filings for non-traded BDC repurchase plan changes
+4. Pull BIZD and HYG closing prices on May 8, 2026 and Dec 31, 2026
+
+---
+
+# Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-08 | Initial publication |
+
+---
+
+*Market Accurate: Tracking the credit cycle's quiet corner.*

--- a/docs/analyst-comparison.md
+++ b/docs/analyst-comparison.md
@@ -85,6 +85,24 @@ Comparing predictions to analyst consensus serves two goals:
 
 ---
 
+### AV-002: Hyperscaler Capex Language Moderation in Q1 2026
+
+| Metric | Market Accurate | Wall Street Consensus |
+|--------|----------------|----------------------|
+| **Prediction** | At least one of MSFT/GOOG/AMZN moderates capex language in Q1 2026 | Continued aggressive expansion |
+| **Direction** | Bearish on demand sustainability | Bullish |
+| **Made** | 2026-01-03 | — |
+| **Contrarian?** | Yes | — |
+
+**Consensus Sources (going into Q1 2026 earnings):**
+- Sell-side aggregations (Bloomberg, Reuters, Futurum) showed combined Big-4 2026 expectations of ~$625–690B before Q1 2026 earnings
+- Goldman Sachs ($500B+ in 2026) and Morgan Stanley (~$600B+) both bullish on durability into 2026
+- No major sell-side firm forecasted explicit moderation language at Q1 2026 calls
+
+**Outcome:** Resolved 2026-05-08. Combined Big-4 2026 guidance now ~$700B midpoint (MSFT $190B; GOOGL $180–190B; AMZN $200B; META $125–145B). No MSFT/GOOG/AMZN moderation language. **Market Accurate INCORRECT; consensus directionally CORRECT.** This is the first resolved comparison where consensus clearly beat us. Contributing factor: the supply-constraint mechanism (Pichai "compute constrained"; Hood "constrained at least through 2026") that emerged in Q1 2026 was not in *either* our or consensus models — but it operates against the demand-moderation thesis, so consensus was right by accident as much as by analysis.
+
+---
+
 ## Tracking Template
 
 When adding new comparisons:
@@ -112,11 +130,11 @@ When adding new comparisons:
 
 | Metric | Value |
 |--------|-------|
-| Total Comparisons | 3 |
-| Contrarian Predictions | 3 |
-| Resolved | 1 |
+| Total Comparisons | 4 |
+| Contrarian Predictions | 4 |
+| Resolved | 2 |
 | Our Correct, Consensus Wrong | 0 |
-| Consensus Correct, We Wrong | 0 |
+| Consensus Correct, We Wrong | 1 (AV-002) |
 | Both Correct | 0 |
 | Both Wrong | 1 (AV-001: actual 75% > both our <50% and consensus ~65%) |
 
@@ -156,4 +174,4 @@ This document will be updated:
 
 ---
 
-*Updated: 2026-01-03*
+*Updated: 2026-05-08 (added AV-002 resolution; consensus beat us for the first time)*

--- a/docs/prediction-calendar.md
+++ b/docs/prediction-calendar.md
@@ -115,6 +115,7 @@ Upcoming prediction verification dates and resolution requirements.
 | DA-003 | USDT+USDC combined supply >$300B in 2026 | DeFiLlama | Track daily supply |
 | DA-004 | No US stablecoin >2% peg break >24h | Price feeds | Monitor USDC/PYUSD/etc. |
 | DA-005 | 2026 BTC drawdown smaller than 77% | Price data | Compute peak-to-trough |
+| PC-004 | BIZD underperforms HYG by ≥10pp May→Dec 2026 | Yahoo Finance | Compare total returns |
 
 **AV-005 Resolution Details:**
 - **Claim:** Combined market cap of NVIDIA + AMD + Arm lower on Dec 31, 2026 than Jan 3, 2026
@@ -137,6 +138,10 @@ Upcoming prediction verification dates and resolution requirements.
 |----|-----------|-------------------|--------|
 | SC-004 | Foundry utilization divergence | TSMC reports/analyst data | Compare trailing vs leading edge |
 | CRE-002 | Class A office REITs outperform B/C by 15%+ | REIT performance data | Compare sector returns |
+| CS-005 | Fed governor/president cites K-shaped consumer | Fed speeches archive | Search 2026 speeches |
+| PC-002 | 5+ public BDCs cut base dividend ≥10% in 2026 | BDC press releases | Track BDC Investor list |
+| PC-003 | Major non-traded BDC redemption gating in 2026 | SEC EDGAR | Search non-traded BDC filings |
+| PC-005 | Major BDC sponsor announces credit business sale/wind-down | SEC 8-K, sponsor IR | Track sponsor announcements |
 
 ### February 2027
 
@@ -149,12 +154,17 @@ Upcoming prediction verification dates and resolution requirements.
 | CRE-004 | San Francisco vacancy >25% through 2026 | CoStar/CBRE | Check SF Q4 2026 vacancy |
 | LM-001 | US unemployment 3.8–4.5%, no AI attribution | BLS, Fed, CBO | Verify unemployment band + source scan |
 | DA-002 | BTC ETF flow/price correlation >0.5 | ETF data + price | Compute rolling correlation |
+| CS-001 | Subprime auto 60+ DPD >6% in ≥3/4 of 2026 quarters | NY Fed Household Debt | Check quarterly delinquency series |
+| CS-003 | Credit card 90+ DPD ≥4% in any 2026 quarter | NY Fed Household Debt | Check quarterly series |
+| CS-004 | 2026 retail sales growth below NRF 4.4% forecast | Census Monthly Retail Trade | Pull annual revision |
+| PC-001 | Median BDC non-accruals ≥4% in any 2026 quarter | KBRA BDC Compendium | Pull each quarterly report |
 
 ### May 2027
 
 | ID | Prediction | Verification Source | Action |
 |----|-----------|-------------------|--------|
 | LM-003 | CSR (BLS 43-4051) ≥5% decline 2024→2026 | BLS OES | Check 2026 OES release |
+| CS-002 | Discount basket beats mid-tier mall by ≥10pp May 2026→Apr 2027 | Yahoo Finance | Compute basket returns |
 
 ### June 30, 2027
 
@@ -190,4 +200,4 @@ When a prediction's verification date arrives:
 
 ---
 
-*Updated: 2026-04-18 (added LM, DA predictions; resolution prep docs now in `docs/prediction-prep/`)*
+*Updated: 2026-05-08 (added CS-001..005 and PC-001..005; resolved AV-002 INCORRECT)*

--- a/docs/prediction-prep/AV-003-prep.md
+++ b/docs/prediction-prep/AV-003-prep.md
@@ -171,3 +171,49 @@ On or before June 30, 2026:
 ---
 
 *Prepared: 2026-04-18*
+
+---
+
+## Addendum (May 8, 2026): Updated candidate list (T-53 days)
+
+With ~7 weeks until resolution, the field of qualifying candidates has expanded substantially since the April prep. The threshold (MMLU ≥86.4 / HumanEval ≥67 / GSM8K ≥92, single RTX 4090) is now cleared by **multiple** independent models, not just DeepSeek-R1-Distill-32B.
+
+### Current top candidates (open-weights, ≤35B parameters, RTX-4090-viable)
+
+| Model | Params | Quant | RTX 4090 fit | MMLU | HumanEval | GSM8K | Source |
+|-------|--------|-------|--------------|------|-----------|-------|--------|
+| DeepSeek-R1-Distill-32B | 32B | Q4 | 20GB ✓ | 87.5% | 85.4% | 95.6% | Jan 2025 release; verified by community reproductions |
+| Qwen 3 32B | 32B | Q4 | 22GB ✓ (~38 tok/s on RTX 4090) | reported ≥87% | reported ≥85% | reported ≥93% | [Awesome Agents leaderboard](https://awesomeagents.ai/leaderboards/home-gpu-llm-leaderboard/), [ToolHalla 2026 RTX 4090 guide](https://toolhalla.ai/blog/best-local-llms-rtx-4090-2026) |
+| Qwen 3 14B | 14B | Q4 | <12GB ✓ | 81.1% | — | — | Below MMLU threshold; flagged for completeness |
+| Qwen3.6-27B | 27B | Q4 | ~16GB ✓ | competitive | reported "beats 397B on coding" | — | [BuildFastWithAI](https://www.buildfastwithai.com/blogs/qwen3-6-27b-review-2026) — needs strict-eval verification |
+| Llama 3.3 70B (Q4 K_M) | 70B | Q4_K_M | ~40GB ✗ | 88% | 89% | 90% | Reportedly does **not** fit single 24GB; multi-GPU only — fails AV-003 hardware criterion |
+
+### Verification status
+
+The DeepSeek-R1-Distill-32B candidate alone is sufficient to resolve AV-003 CORRECT subject to the strict-eval verification steps in the original prep doc. As of May 8, 2026:
+
+- ✅ Weights publicly downloadable (HuggingFace)
+- ✅ Q4 GGUF format usable in llama.cpp / Ollama / vLLM
+- ✅ Fits in 24GB VRAM with usable context window
+- ⚠️ Need to confirm: Q4-quantized scores (not FP16 reference scores) clear all three thresholds
+- ⚠️ Need to confirm: at least one independent community reproduction posted
+
+### Failure modes still in play
+
+1. **Quant degradation:** If Q4 quantization drops MMLU below 86.4%, falls back to needing FP8 or higher precision, which doesn't fit in 24GB.
+2. **Benchmark contamination claim:** If a credible analysis emerges that DeepSeek's training data included GSM8K or HumanEval test sets, scores get discounted.
+3. **Llama 3.3 confusion:** Llama 3.3 70B reportedly hits all three thresholds but requires multi-GPU — does NOT satisfy AV-003 hardware constraint.
+
+### Updated probability: ~95% CORRECT
+
+(Up from ~90% at April prep. Multiple independent candidates now exist.)
+
+### Resolution actions in the next 4 weeks
+
+1. **By May 30:** Pull Q4 GGUF for DeepSeek-R1-Distill-32B and Qwen 3 32B. Run LM Eval Harness for MMLU 5-shot, HumanEval pass@1, GSM8K 8-shot CoT on a single RTX 4090 (or document a community result that has).
+2. **By June 15:** If primary candidate fails on quantized eval, fall back to next candidate. If all candidates fail, prepare INCORRECT resolution doc.
+3. **By June 30:** Final resolution.
+
+---
+
+*Addendum: 2026-05-08*

--- a/docs/prediction-prep/AV-005-prep.md
+++ b/docs/prediction-prep/AV-005-prep.md
@@ -1,0 +1,102 @@
+# Prediction Resolution Prep: AV-005
+
+## Prediction Details
+
+| Field | Value |
+|-------|-------|
+| ID | AV-005 |
+| Claim | Combined market cap of NVIDIA + AMD + Arm will be **lower** on Dec 31, 2026 than on Jan 3, 2026 |
+| Made | 2026-01-03 |
+| Resolves | 2026-12-31 |
+| Status | Pending |
+
+---
+
+## Baseline (Jan 3, 2026)
+
+The original AI Valuation Analysis stated NVIDIA market cap "~$3.0T" — that figure was stale at publication. Reconciled against contemporaneous sources, the actual Jan 3, 2026 baseline is:
+
+| Ticker | Market Cap (Jan 3, 2026) | Source |
+|--------|-------------------------|--------|
+| NVDA | ~$4.50T | [Intellectia / multiple aggregators](https://intellectia.ai/news/stock/nvidia-reaches-45-trillion-market-cap-data-center-business-could-double-by-2026); pullback from $5T peak in Oct 2025 |
+| AMD | ~$0.25T (≈$155 share × 1.62B shares) | Macrotrends, public.com historical |
+| ARM | ~$0.155T (≈$140 share × 1.05B shares) | Macrotrends, companiesmarketcap |
+| **Combined** | **~$4.91T** | — |
+
+**Data-discipline note:** The published analysis used ~$3.0T for NVIDIA, which would have implied a ~$3.4T baseline. Using the corrected ~$4.5T baseline gives ~$4.91T combined. The threshold for AV-005 resolution is **whichever baseline a reasonable third party can verify on Jan 3, 2026** — i.e. ~$4.91T. The published $3.0T figure is a known error in the source document and the resolution should not be evaluated against it. (Per the immutability protocol, the prediction text itself is unchanged; only the baseline-data clarification is updated here.)
+
+---
+
+## Interim Status (May 7–8, 2026)
+
+| Ticker | Market Cap (May 7, 2026) | YTD Change | Source |
+|--------|-------------------------|------------|--------|
+| NVDA | ~$5.05T | +12% | [Capital.com](https://capital.com/en-int/markets/shares/nvidia-corp-share-price/market-cap), [CNBC: $5T close](https://www.cnbc.com/2026/04/24/nvidia-stock-closes-at-record-pushing-market-cap-past-5-trillion.html) |
+| AMD | ~$0.687T | +175% | [public.com AMD market cap](https://public.com/stocks/amd/market-cap), all-time high $421.39 close on May 6, 2026 |
+| ARM | ~$0.245T | +58% | [Capital.com ARM](https://capital.com/en-int/markets/shares/arm-holdings-plc-share-price-1/market-cap), [companiesmarketcap](https://companiesmarketcap.com/arm-holdings/marketcap/) |
+| **Combined** | **~$5.98T** | **+22%** | — |
+
+For AV-005 to resolve CORRECT, the combined market cap on Dec 31, 2026 must be **less than ~$4.91T** — i.e. the trio must give back the entire ~$2.5T of gains booked in the last 16 months and then some, in roughly 7.5 months.
+
+**Probability assessment as of May 8, 2026:** The combined trio would need to fall ~18% from current levels just to revert to the Jan 3 baseline, and ~25%+ to clear the threshold meaningfully. This is not impossible (AI semis have shown 25%+ drawdowns multiple times in 24 months) but is now substantially harder than at January 2026.
+
+Subjective probability of CORRECT resolution: **~15%** (down from an implicit ~40% at publication).
+
+---
+
+## Resolution Protocol
+
+### Threshold
+
+CORRECT iff: NVDA(Dec 31, 2026 close) + AMD(Dec 31, 2026 close) + ARM(Dec 31, 2026 close) all in market-cap terms, summed, is **strictly less than** ~$4.91T (the Jan 3, 2026 baseline).
+
+### Tie-breaker
+
+Per the pre-registration framework default for numerical thresholds: strict inequality. A combined market cap exactly equal to or above the baseline → INCORRECT.
+
+### Source
+
+Yahoo Finance closing market cap on Dec 31, 2026 (or last trading day of 2026 if Dec 31 is a weekend) for each ticker. Cross-check with companiesmarketcap.com and one of the listed exchange data feeds.
+
+### Edge cases
+
+- **Stock splits:** Use share counts as of Dec 31, 2026; market cap is the same regardless of split.
+- **M&A:** If AMD or ARM is acquired and delisted, use the last reported market cap before delisting.
+- **NVIDIA fiscal year offset:** Irrelevant — calendar Dec 31 closing prices apply.
+
+---
+
+## What would change this read
+
+The probability of CORRECT resolution rises materially if any of these happen between now and December 2026:
+
+1. **AI capex air-pocket:** A hyperscaler explicitly cuts 2026 H2 capex (HC-002 trigger) — direct read-through to NVDA/AMD orders.
+2. **DeepSeek-style efficiency event:** A new open-source release that materially undermines API/training compute demand.
+3. **HBM/memory price collapse:** Would compress NVDA gross margin and trigger valuation derate.
+4. **Recession or rate shock:** Cyclical drawdown across high-beta semis.
+5. **Antitrust action:** US, EU, or China regulatory move against NVIDIA's GPU dominance.
+6. **Supply unblock:** If the supply-constraint story unwinds (transformers, power) faster than demand grows, NVDA's pricing power erodes.
+
+Absent at least one of these, AV-005 resolves INCORRECT.
+
+---
+
+## Mechanism update vs. the original thesis
+
+The January 2026 AI Valuation Analysis bet on **demand destruction via efficiency**. Q1 2026 earnings (resolved AV-002 INCORRECT on May 8, 2026) instead showed **demand exceeding supply**, with $700B combined Big-4 capex guidance. The mechanism that originally supported AV-005 — efficiency erodes the value of compute scarcity — is not currently visible in price action; if anything, the supply-constraint story has *increased* the value of installed GPU capacity.
+
+For AV-005 to flip back to favorable, the *channel* by which efficiency would transmit into the trio's market cap needs to either (a) re-emerge in the form an efficiency event large enough to reset expectations, or (b) get blocked by a separate cyclical / regulatory shock.
+
+---
+
+## Sources
+
+- [companiesmarketcap.com NVDA](https://companiesmarketcap.com/nvidia/marketcap/)
+- [companiesmarketcap.com ARM](https://companiesmarketcap.com/arm-holdings/marketcap/)
+- [Macrotrends AMD market cap](https://www.macrotrends.net/stocks/charts/AMD/amd/market-cap)
+- [Macrotrends ARM market cap](https://www.macrotrends.net/stocks/charts/ARM/arm-holdings/market-cap)
+- Original prediction: [analysis/ai-valuation-2026-01.md](../../analysis/ai-valuation-2026-01.md#prediction-5-ai-infrastructure-valuation-compression)
+
+---
+
+*Prepared: 2026-05-08*

--- a/docs/prediction-prep/EA-001-prep.md
+++ b/docs/prediction-prep/EA-001-prep.md
@@ -154,3 +154,70 @@ By June 30, 2026:
 ---
 
 *Prepared: 2026-04-18*
+
+---
+
+## Addendum (May 8, 2026): Current state of 2027 forecasts (T-53 days)
+
+### Gartner
+
+**Headline 2026 forecast (Jan 15, 2026 release):** Total worldwide AI spending will reach $2.52T in 2026, +44% YoY ([Gartner press release Jan 15 2026](https://www.gartner.com/en/newsroom/press-releases/2026-1-15-gartner-says-worldwide-ai-spending-will-total-2-point-5-trillion-dollars-in-2026), [Next Platform analysis Jan 30 2026](https://www.nextplatform.com/2026/01/30/gartner-takes-another-stab-at-forecasting-ai-spending/)).
+
+**2027 outlook (per Gartner sub-forecasts and analyst commentary):**
+
+| Category | 2026 growth | 2027 growth | <25% threshold? |
+|----------|-------------|-------------|-----------------|
+| Total worldwide AI spending | +44% | reported "growth rate will slow in 2027 from 2026" — no specific number released | Indeterminate |
+| AI software (specific) | 17.8% (forecast), grows to $297B by 2027 | **20.4%** (Gartner 2023-2027 forecast, 19.1% CAGR) | **Yes** |
+| AI infrastructure | very high | slows but no number | Indeterminate |
+| GenAI models | 80.8% (Gartner Feb 2026) | not specified | Indeterminate |
+
+**Key Gartner data point that potentially resolves CORRECT:** The Gartner "Forecast Analysis: Artificial Intelligence Software, 2023-2027, Worldwide" report shows AI software market growth decelerating from 17.8% (2023-2026 average) to 20.4% in 2027, a 19.1% CAGR — both below 25%.
+
+**Caveat:** This is the AI software sub-segment, not total enterprise AI spending. Per the prep doc (Section "Category normalization"), this is **acceptable** as "AI software spending growth" is one of the listed acceptable definitions. Reject only if "only forecasting AI infrastructure" — software is broader and acceptable.
+
+### IDC
+
+**2025–2029 CAGR:** 31.9% (driven by Agentic AI to $1.3T by 2029) ([IDC press release](https://my.idc.com/getdoc.jsp?containerId=prUS53765225)).
+
+**2025 → 2028 trajectory:** $307B → $632B implies ~27% CAGR.
+
+**Specific 2027 YoY:** Not yet published in a single-year breakout. IDC's Worldwide AI Spending Guide H1 2026 release expected before EA-001 resolution date.
+
+**Read:** IDC remains above 25% on aggregate AI spending. Does NOT support CORRECT resolution from IDC alone.
+
+### Forrester
+
+**No 2027-specific public forecast yet found at time of writing.** Forrester typically publishes 2027 figures in Q4 2026 Predictions report (October–November 2026), which would be **after** the EA-001 resolution date.
+
+If Forrester does not publish a 2027 figure by June 30, 2026, it cannot contribute to CORRECT or INCORRECT.
+
+### Read at T-53 days
+
+| Source | 2027 forecast status | Potentially resolves CORRECT? |
+|--------|---------------------|-------------------------------|
+| **Gartner (AI software sub-segment)** | 20.4% YoY for 2027 (in 2023-2027 forecast doc) | **Yes** — already below threshold |
+| Gartner (total AI spending) | "Growth rate will slow" but no 2027 number released | Indeterminate |
+| IDC (total AI spending) | ~27% implicit, ~32% CAGR through 2029 | No |
+| Forrester | No 2027 figure expected pre-resolution | No |
+
+### Probability update
+
+The Gartner AI software 2027 figure of ~20.4% likely satisfies the EA-001 threshold under a fair reading of the prep doc's category-normalization rules. There is a reasonable INCORRECT-defense argument that the Gartner total (which is what most readers would think of as "enterprise AI spending") is still well above 25% and that the software sub-segment is too narrow.
+
+**Strict-reading resolution:** Likely **CORRECT** (Gartner AI software 19.1% CAGR / 20.4% 2027).
+
+**Conservative-reading resolution:** **INDETERMINATE** until Gartner or IDC publishes a top-line 2027 AI spending growth number specifically below 25%.
+
+**Subjective probability of CORRECT resolution by June 30, 2026: ~70%** (up from 65% at April prep, given the Gartner AI software figures already in the public domain).
+
+### Resolution actions in the next 4 weeks
+
+1. **By May 22:** Pull the most recent Gartner "Forecast Analysis: Artificial Intelligence Software, 2023-2027" or successor document. Confirm 20.4% / 19.1% figures stand.
+2. **By June 1:** Check whether IDC publishes its H1 2026 Worldwide AI Spending Guide update with explicit 2027 YoY rate.
+3. **By June 15:** Check Forrester for any 2027 AI spending update tied to mid-year planning cycles.
+4. **By June 30:** Final resolution. If Gartner AI software 20.4% figure is the strongest candidate, document the category-narrowness caveat in the resolution note.
+
+---
+
+*Addendum: 2026-05-08*

--- a/predictions/tracker.md
+++ b/predictions/tracker.md
@@ -11,7 +11,7 @@ This file tracks all predictions made by Market Accurate analyses, their outcome
 | ID | Prediction | Made | Resolves | Status |
 |----|-----------|------|----------|--------|
 | AV-001 | NVIDIA Q4 FY26 datacenter revenue YoY growth <50% | 2026-01-03 | 2026-02 | **Resolved: INCORRECT** |
-| AV-002 | Hyperscaler capex language moderation in Q1 2026 | 2026-01-03 | 2026-05 | Pending |
+| AV-002 | Hyperscaler capex language moderation in Q1 2026 | 2026-01-03 | 2026-05 | **Resolved: INCORRECT** |
 | AV-003 | Open-weights model matches GPT-4 on consumer GPU | 2026-01-03 | 2026-06-30 | Pending |
 | AV-004 | Enterprise AI spend growth intentions <25% YoY | 2026-01-03 | 2026-10 | Pending |
 | AV-005 | NVIDIA+AMD+Arm combined market cap lower than Jan 3 | 2026-01-03 | 2026-12-31 | Pending |
@@ -98,6 +98,26 @@ This file tracks all predictions made by Market Accurate analyses, their outcome
 | DA-004 | No US-regulated stablecoin >2% peg break for >24 hours in 2026 | 2026-04-18 | 2026-12-31 | Pending | 80% |
 | DA-005 | 2026 BTC drawdown (if any) smaller than 77% (2022 analogue) | 2026-04-18 | 2026-12-31 | Pending | 60% |
 
+### Consumer Spending & Retail Cycle (2026-05-08)
+
+| ID | Prediction | Made | Resolves | Status | Confidence |
+|----|-----------|------|----------|--------|------------|
+| CS-001 | Subprime auto 60+ DPD stays >6.0% in ≥3/4 quarters of 2026 | 2026-05-08 | 2027-02-28 | Pending | 70% |
+| CS-002 | Discount retailer basket (DG/DLTR/FIVE) beats mid-tier mall (M/KSS/GPS) by ≥10pp May 2026→Apr 2027 | 2026-05-08 | 2027-05-07 | Pending | 55% |
+| CS-003 | Aggregate credit card 90+ DPD ≥4.0% in any 2026 quarter | 2026-05-08 | 2027-02-28 | Pending | 45% |
+| CS-004 | 2026 US retail sales growth below NRF's 4.4% forecast | 2026-05-08 | 2027-02-17 | Pending | 55% |
+| CS-005 | Fed governor or Reserve Bank president cites "K-shaped" consumer in 2026 | 2026-05-08 | 2027-01-31 | Pending | 75% |
+
+### Private Credit & BDC Sector (2026-05-08)
+
+| ID | Prediction | Made | Resolves | Status | Confidence |
+|----|-----------|------|----------|--------|------------|
+| PC-001 | KBRA-universe median BDC non-accruals at cost ≥4.0% in any 2026 quarter | 2026-05-08 | 2027-02-28 | Pending | 55% |
+| PC-002 | 5+ public BDCs (>$500M cap) cut base dividend by ≥10% in 2026 | 2026-05-08 | 2027-01-31 | Pending | 70% |
+| PC-003 | Major non-traded BDC (>$10B AUM) invokes redemption gate or suspends repurchases in 2026 | 2026-05-08 | 2027-01-31 | Pending | 50% |
+| PC-004 | BIZD underperforms HYG by ≥10pp May 8 → Dec 31, 2026 | 2026-05-08 | 2027-01-01 | Pending | 55% |
+| PC-005 | At least one major BDC sponsor announces strategic transaction (sale/merger/wind-down) of credit business in 2026 | 2026-05-08 | 2027-01-31 | Pending | 40% |
+
 ---
 
 ## Resolved Predictions
@@ -105,6 +125,7 @@ This file tracks all predictions made by Market Accurate analyses, their outcome
 | ID | Prediction | Made | Resolved | Outcome | Correct? |
 |----|-----------|------|----------|---------|----------|
 | AV-001 | NVIDIA Q4 FY26 datacenter revenue YoY growth <50% | 2026-01-03 | 2026-02-25 | Data Center $62.3B (+75% YoY vs $35.6B prior year) | **No** |
+| AV-002 | Hyperscaler capex language moderation in Q1 2026 | 2026-01-03 | 2026-05-08 | All four hyperscalers raised or reiterated 2026 capex; no MSFT/GOOG/AMZN exec used moderation language. MSFT $190B (+~$96B), GOOGL $180–190B (raised from $175–185B), AMZN $200B (reiterated), META $125–145B (raised from $115–135B). Dominant narrative: "compute constrained" + component pricing. | **No** |
 
 ---
 
@@ -112,21 +133,21 @@ This file tracks all predictions made by Market Accurate analyses, their outcome
 
 | Metric | Value |
 |--------|-------|
-| Total Predictions | 42 |
-| Resolved | 1 |
+| Total Predictions | 52 |
+| Resolved | 2 |
 | Correct | 0 |
-| Incorrect | 1 |
-| Accuracy | 0% (n=1) |
-| Brier Score | 0.25 (n=1; see note) |
+| Incorrect | 2 |
+| Accuracy | 0% (n=2) |
+| Brier Score | 0.25 (n=2; see note) |
 | Calibration | Insufficient data (need n≥30) |
 
-**Brier score note:** AV-001 did not state an explicit ex-ante probability (the AI Valuation Analysis predates the pre-registration framework's probability-disclosure requirement). Per the framework, predictions without stated probability are scored at 0.50 — yielding (0.50 − 0)² = 0.25. Future predictions must carry explicit probabilities to enable proper Brier calculation.
+**Brier score note:** Neither AV-001 nor AV-002 stated an explicit ex-ante probability at publication (the original AI Valuation Analysis predates the pre-registration framework's probability-disclosure requirement). Per the framework, predictions without stated probability are scored at 0.50 — yielding (0.50 − 0)² = 0.25 each. The AV-002 prep-doc addendum noted a subjective probability of ~75% before resolution, but that was not the published ex-ante; using the published-default 0.50 per protocol. Future predictions must carry explicit probabilities at publication to enable proper Brier calculation.
 
 ### By Analysis
 
 | Analysis | Predictions | Resolved | Correct | Accuracy |
 |----------|-------------|----------|---------|----------|
-| AI Valuation | 7 | 1 | 0 | 0% |
+| AI Valuation | 7 | 2 | 0 | 0% |
 | Hyperscaler Capex | 2 | 0 | 0 | N/A |
 | Semiconductor Cycle | 6 | 0 | 0 | N/A |
 | Open-Source Benchmarks | 3 | 0 | 0 | N/A |
@@ -136,6 +157,8 @@ This file tracks all predictions made by Market Accurate analyses, their outcome
 | Commercial Real Estate | 4 | 0 | 0 | N/A |
 | Labor Market & AI | 4 | 0 | 0 | N/A |
 | Digital Assets Cycle | 5 | 0 | 0 | N/A |
+| Consumer Spending | 5 | 0 | 0 | N/A |
+| Private Credit & BDC | 5 | 0 | 0 | N/A |
 
 ---
 
@@ -209,6 +232,7 @@ Under-confidence = accuracy higher than stated confidence.
 | Date | ID | Action | Evidence |
 |------|----|--------|----------|
 | 2026-04-19 | AV-001 | Resolved INCORRECT | NVIDIA Q4 FY26 Data Center revenue $62.3B (+75% YoY) reported Feb 25, 2026 — well above the <50% threshold. Sources: [CNBC](https://www.cnbc.com/2026/02/25/nvidia-nvda-earnings-report-q4-2026.html), [ServeTheHome](https://www.servethehome.com/nvidia-reports-q4-fy2026-earnings-data-center-and-proviz-drive-revenue-records/), [NVIDIA FY25 press release](https://nvidianews.nvidia.com/news/nvidia-announces-financial-results-for-fourth-quarter-and-fiscal-2025) for the $35.6B Q4 FY25 baseline. |
+| 2026-05-08 | AV-002 | Resolved INCORRECT | Q1 2026 calendar earnings cycle (April 29 – May 1, 2026) produced no moderation language from MSFT/GOOG/AMZN. All four hyperscalers raised or reiterated aggressive 2026 capex: Microsoft ~$190B for calendar 2026 (incl. ~$25B for higher component pricing); Alphabet raised range to $180–190B (from $175–185B); Amazon reiterated $200B; Meta raised to $125–145B (from $115–135B). Dominant exec language was supply-side ("compute constrained" — Pichai; "constrained at least through 2026" — Hood) and component-cost driven, not capex-rate moderation. The single ambiguous candidate — Hood's reference to "the efficiencies we're already driving across the platform" — was framed as confidence in returns supporting *more* spend, not moderation. Sources: [CNBC: Microsoft Q3 FY2026](https://www.cnbc.com/2026/04/29/microsoft-msft-q3-earnings-report-2026.html), [The Register: $190B capex](https://www.theregister.com/2026/04/30/microsoft_q3_2026/), [CNBC: Alphabet Q1 2026](https://www.cnbc.com/2026/04/29/alphabet-googl-q1-2026-earnings.html), [Alphabet Q1 release](https://www.sec.gov/Archives/edgar/data/1652044/000165204426000043/googexhibit991q12026.htm), [CNBC: Amazon Q1 2026](https://www.cnbc.com/2026/04/29/amazon-amzn-q1-earnings-report-2026.html), [Meta Q1 release](https://investor.atmeta.com/investor-news/press-release-details/2026/Meta-Reports-First-Quarter-2026-Results/default.aspx), [Fortune: Meta $145B](https://fortune.com/2026/04/29/meta-zuckerberg-145-billion-ai-spending-roi/). |
 
 ---
 
@@ -226,4 +250,4 @@ Under-confidence = accuracy higher than stated confidence.
 
 ---
 
-*Updated: 2026-04-19 (resolved AV-001 as INCORRECT; added LM-001 through LM-004, DA-001 through DA-005; see [docs/pre-registration.md](/docs/pre-registration.md) for resolution protocol)*
+*Updated: 2026-05-08 (resolved AV-002 as INCORRECT after Q1 2026 hyperscaler earnings cycle)*


### PR DESCRIPTION
## Summary

This PR adds two new sector analyses (Consumer Spending & Retail Cycle, Private Credit & BDC Sector) published May 8, 2026, resolves prediction AV-002 as INCORRECT based on Q1 2026 earnings outcomes, and updates supporting documentation with May 2026 data refreshes.

## Key Changes

**New Analyses:**
- `analysis/consumer-spending-2026-05.md` — K-shaped consumer thesis with 5 falsifiable predictions (CS-001 through CS-005) on subprime auto delinquencies, retail sector bifurcation, and credit card stress through 2027
- `analysis/private-credit-2026-05.md` — Mark-to-model NAV resilience in BDCs during redemption pressure, with 5 predictions (PC-001 through PC-005) on non-accrual migration, dividend cuts, and sponsor M&A through 2027

**Prediction Resolution:**
- AV-002 resolved INCORRECT (May 8, 2026): Hyperscaler capex language moderation did not occur; instead MSFT/GOOG/AMZN/META all raised or reiterated 2026 capex guidance to ~$700B combined midpoint, citing supply constraints and component pricing
- Updated `predictions/tracker.md` with AV-002 outcome and added 10 new predictions (CS-001–CS-005, PC-001–PC-005)

**Data Refreshes:**
- `analysis/hyperscaler-capex-2026-01.md` — Added May 2026 update section with Q1 2026 reported capex ($130.6B combined Big-4), revised 2026 full-year guidance ($700B midpoint), and component-pricing mechanism explanation
- `analysis/open-source-benchmarks-2026-01.md` — Refreshed May 2026 leaderboard with Qwen 3 releases, updated metrics dashboard showing multiple RTX-4090-viable candidates now clearing AV-003 thresholds
- `docs/prediction-prep/AV-005-prep.md` — Added interim status (May 7, 2026) showing combined NVDA+AMD+ARM market cap at ~$5.98T (+22% YoY), reducing AV-005 CORRECT probability to ~15%
- `docs/prediction-prep/AV-003-prep.md` — Added May 8 addendum with expanded candidate list (Qwen 3 32B, Qwen 3.6-27B) and verification status for DeepSeek-R1-Distill-32B
- `docs/prediction-prep/EA-001-prep.md` — Added May 8 addendum on 2027 AI spending forecasts; Gartner AI software sub-segment shows 20.4% 2027 growth (below 25% threshold), potentially supporting CORRECT resolution

**Documentation Updates:**
- `docs/analyst-comparison.md` — Added AV-002 comparison showing Market Accurate bearish (moderation expected) vs. consensus bullish (continued expansion); outcome: consensus correct, MA incorrect
- `docs/prediction-calendar.md` — Added PC-004 (BIZD vs HYG tracking) to May–December 2026 monitoring list
- `CLAUDE.md` — Updated project status to reflect two new analyses and expanded prediction set to 42 total
- `CONTRIBUTING.md` — Marked consumer spending and private credit analyses as completed

## Notable Implementation Details

- Both new analyses follow the established format: executive summary, key metrics table, mark-to-model/K-shape thesis definition with evidence, bull/bear case mechanisms, predictions with ex-ante probabilities, disconfirming evidence, and cross-analysis connections
- AV-002 resolution includes explicit acknowledgment that the supply-constraint mechanism (Pichai "compute constrained," Hood "constrained at least through 2026") was not in either Market Accurate or consensus models pre-earnings, but emerged as the actual driver of guidance increases
- Private credit analysis identifies mark-to-model NAV smoothing as the structural vulnerability, with BCRED's $400M sponsor injection and FS K

https://claude.ai/code/session_01L492ohYzvZHTLyZvzgEQfG